### PR TITLE
UIPBEX-21: Support `feesfines` interface version `17.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (IN PROGRESS)
 
+* Support `feesfines` interface version `17.0`. Refs UIPBEX-21.
+
 ## [1.1.2](https://github.com/folio-org/ui-plugin-bursar-export/tree/v1.1.2) (2021-07-28)
 [Full Changelog](https://github.com/folio-org/ui-plugin-bursar-export/compare/v1.1.1...v1.1.2)
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "displayName": "ui-plugin-bursar-export.meta.title",
     "okapiInterfaces": {
       "users": "15.0",
-      "feesfines": "16.0",
+      "feesfines": "16.0 17.0",
       "data-export-spring": "1.0"
     },
     "stripesDeps": [


### PR DESCRIPTION
## Do not merge

## Purpose
Support `feesfines` interface version `17.0`

## Approach
We should merge all associated task with https://issues.folio.org/browse/MODFEE-98 in the same time. In scope of https://issues.folio.org/browse/MODFEE-98 was added the standard UUID regular expression pattern to all the id fields in the Fees/Fines module JSON schemas. All changes was tested in scope https://issues.folio.org/browse/MODFEE-197.

## Refs
https://issues.folio.org/browse/UIPBEX-21

#### TODOS and Open Questions
@zburke @mkuklis @NikitaSedyx @uladislausamets Could you please clarify do we need to add someone else for review this task?