### PR TITLE
UIPBEX-29 purge unused uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Rename the label "Max. days outstanding" to "Fees/Fines older than (days)". Refs UIPBEX-27
 * Refactor psets away from backend ".all" permissions. Refs UIPBEX-26
+* Purge `uuid` since it is no longer in use. Refs UIPBEX-29
 
 ## [2.0.0](https://github.com/folio-org/ui-plugin-bursar-export/tree/v2.0.0) (2021-10-06)
 [Full Changelog](https://github.com/folio-org/ui-plugin-bursar-export/compare/v1.1.2...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -94,8 +94,7 @@
     "react-final-form-arrays": "^3.1.0",
     "react-final-form-listeners": "^1.0.2",
     "react-hot-loader": "^4.3.12",
-    "react-router-prop-types": "^1.0.4",
-    "uuid": "^3.0.1"
+    "react-router-prop-types": "^1.0.4"
   },
   "peerDependencies": {
     "@folio/stripes": "^7.0.0",


### PR DESCRIPTION
Since `uuid` is not in use it may be removed.

CC: @uladislausamets, @vashjs 

Refs [UIPBEX-29](https://issues.folio.org/browse/UIPBEX-29)

