### PR TITLE
UIPBEX-45: Support feesfines interface version 18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-plugin-bursar-export
 
 ## (IN PROGRESS)
+* Support `feesfines` interface version `18.0`. Refs UIPBEX-45.
 
 ## [2.4.0](https://github.com/folio-org/ui-plugin-bursar-export/tree/v2.4.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-plugin-bursar-export/compare/v2.3.0...v2.4.0)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "displayName": "ui-plugin-bursar-export.meta.title",
     "okapiInterfaces": {
       "users": "15.0 16.0",
-      "feesfines": "16.0 17.0",
+      "feesfines": "16.0 17.0 18.0",
       "data-export-spring": "1.0"
     },
     "stripesDeps": [


### PR DESCRIPTION
## Purpose
Support feesfines interface version 18.0

## Approach
In /feefineactions  (https://s3.amazonaws.com/foliodocs/api/mod-feesfines/r/feefineactions.html)  createdAt field was changed from string to UUID string and added originalCreatedAt field.
These changes do not affect this module and we just need to update the interface.

## Refs
https://issues.folio.org/browse/UIPBEX-45

## Notes 
Associated with https://issues.folio.org/browse/MODFEE-315.
@uladislausamets  Could you please notify us if we miss something?