### PR TITLE
UIPBEX-55: Also support feesfines interface version 19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 [Full Changelog](https://github.com/folio-org/ui-plugin-bursar-export/compare/v2.4.0...v3.0.0)
 * Support `feesfines` interface version `18.0`. Refs UIPBEX-45.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UICAL-275
+* *BREAKING* Upgrade react v18.0.0. Refs FOLIO-3876.
+* *BREAKING* Upgrade dependent modules.
 
 ## [2.4.0](https://github.com/folio-org/ui-plugin-bursar-export/tree/v2.4.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-plugin-bursar-export/compare/v2.3.0...v2.4.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 # Change history for ui-plugin-bursar-export
 
 ## 3.1.0 (IN PROGRESS)
+* Also support `feesfines` interface version `19.0`. Refs UIPBEX-55.
 
 ## [3.0.0](https://github.com/folio-org/ui-plugin-bursar-export/tree/v3.0.0) (2023-10-16)
 [Full Changelog](https://github.com/folio-org/ui-plugin-bursar-export/compare/v2.4.0...v3.0.0)
 * Support `feesfines` interface version `18.0`. Refs UIPBEX-45.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UICAL-275
-* *BREAKING* Upgrade react v18.0.0. Refs FOLIO-3876.
-* *BREAKING* Upgrade dependent modules.
 
 ## [2.4.0](https://github.com/folio-org/ui-plugin-bursar-export/tree/v2.4.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-plugin-bursar-export/compare/v2.3.0...v2.4.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-bursar-export",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Bursar export",
   "main": "index.js",
   "repository": "",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "displayName": "ui-plugin-bursar-export.meta.title",
     "okapiInterfaces": {
       "users": "15.0 16.0",
-      "feesfines": "16.0 17.0 18.0",
+      "feesfines": "16.0 17.0 18.0 19.0",
       "data-export-spring": "1.0"
     },
     "stripesDeps": [


### PR DESCRIPTION
## Purpose
Also support `feesfines` interface version `19.0`

## Approach
Changes was in endpoint `/accounts` that do not used in current module
This is part of `Quesnelia (R1 2024)` release
Should be merged after merging https://issues.folio.org/browse/MODFEE-337

## Refs
https://issues.folio.org/browse/UIPBEX-55