### PR TITLE
[UXPROD-3903] Support data-export-spring interface 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.1.0 (IN PROGRESS)
 * Also support `feesfines` interface version `19.0`. Refs UIPBEX-55.
+* Support `data-export-spring` interface `v2.0`. Refs UXPROD-3903.
 
 ## [3.0.0](https://github.com/folio-org/ui-plugin-bursar-export/tree/v3.0.0) (2023-10-16)
 [Full Changelog](https://github.com/folio-org/ui-plugin-bursar-export/compare/v2.4.0...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "okapiInterfaces": {
       "users": "15.0 16.0",
       "feesfines": "16.0 17.0 18.0 19.0",
-      "data-export-spring": "1.0"
+      "data-export-spring": "1.0 2.0"
     },
     "stripesDeps": [
       "@folio/stripes-acq-components"


### PR DESCRIPTION
# [Jira UXPROD-3903](https://folio-org.atlassian.net/browse/UXPROD-3903)

> [!IMPORTANT]
> This is NOT a replacement for #108; this is a provisional PR to permit the backend being merged without breaking snapshot.
> This PR (or #108) **must** be merged before https://github.com/folio-org/mod-data-export-spring/pull/270, otherwise the snapshot environment will break.

## Purpose
Work being done by @folio-org/bama in [mod-data-export-spring](https://github.com/folio-org/mod-data-export-spring/pull/270) and related modules necessitated a breaking change in the provided `data-export-spring` interface, bumping its version to `2.0`.  A separate PR (#108) is in progress to support this interface within this module, however, we'd like to merge the backend PRs before this is ready.
