### PR TITLE
UIPBEX-58: Add error checking for invalid config.

### DIFF
--- a/src/api/dto/from/dtoToAggregateCriteria.test.ts
+++ b/src/api/dto/from/dtoToAggregateCriteria.test.ts
@@ -61,4 +61,16 @@ describe('dtoToAggregateCriteria', () => {
       },
     ],
   ])('with EUR dtoToAggregateCriteria(%s) === %s', (input, expected) => expect(dtoToAggregateCriteria(input, { currency: 'EUR' } as StripesType, intlEu)).toEqual(expected));
+
+  test.each<[BursarExportFilterAggregate | undefined, CriteriaAggregate | undefined]>([
+    [
+      {
+        type: 'Aggregate',
+        property: 'TOTAL_AMOUNT',
+        condition: 'GREATER_THAN',
+        amount: ('' as unknown) as number,
+      },
+      undefined
+    ],
+  ])('with undefined amount dtoToAggregateCriteria(%s) === %s', (input, expected) => expect(dtoToAggregateCriteria(input, { currency: 'USD' } as StripesType, intlEu)).toEqual(expected));
 });

--- a/src/api/dto/from/dtoToAggregateCriteria.ts
+++ b/src/api/dto/from/dtoToAggregateCriteria.ts
@@ -10,10 +10,13 @@ import { BursarExportFilterAggregate } from '../dto-types';
 
 // inverse of ../to/aggregateCriteriaToFilterDto
 export default function dtoToAggregateCriteria(
-  filter: BursarExportFilterAggregate | undefined,
+  filter: Partial<BursarExportFilterAggregate>,
   stripes: StripesType,
   intl: IntlShape,
 ): CriteriaAggregate | undefined {
+  if (!filter || typeof filter.property !== 'string' || typeof filter.condition !== 'string' || typeof filter.amount !== 'number') {
+    return undefined;
+  }
   switch (filter?.property) {
     case CriteriaTokenType.NUM_ROWS:
       return {

--- a/src/api/dto/from/dtoToAggregateCriteria.ts
+++ b/src/api/dto/from/dtoToAggregateCriteria.ts
@@ -10,7 +10,7 @@ import { BursarExportFilterAggregate } from '../dto-types';
 
 // inverse of ../to/aggregateCriteriaToFilterDto
 export default function dtoToAggregateCriteria(
-  filter: Partial<BursarExportFilterAggregate>,
+  filter: Partial<BursarExportFilterAggregate> | undefined,
   stripes: StripesType,
   intl: IntlShape,
 ): CriteriaAggregate | undefined {

--- a/src/api/dto/from/dtoToCriteria.ts
+++ b/src/api/dto/from/dtoToCriteria.ts
@@ -17,7 +17,7 @@ import {
 } from '../dto-types';
 
 export function dtoToConditionCriteria(
-  filter: BursarExportFilterCondition,
+  filter: Partial<BursarExportFilterCondition>,
   feeFineTypes: FeeFineTypeDTO[],
   locations: LocationDTO[],
   stripes: StripesType,
@@ -27,30 +27,30 @@ export function dtoToConditionCriteria(
     return {
       type: CriteriaGroupType.ALL_OF,
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      criteria: filter.criteria.map((criteria) => dtoToCriteria(criteria, feeFineTypes, locations, stripes, intl)),
+      criteria: filter.criteria?.map((criteria) => dtoToCriteria(criteria, feeFineTypes, locations, stripes, intl)) ?? [],
     };
   } else {
     return {
       type: CriteriaGroupType.ANY_OF,
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      criteria: filter.criteria.map((criteria) => dtoToCriteria(criteria, feeFineTypes, locations, stripes, intl)),
+      criteria: filter.criteria?.map((criteria) => dtoToCriteria(criteria, feeFineTypes, locations, stripes, intl)) ?? [],
     };
   }
 }
 
 export function dtoToNegationCriteria(
-  filter: BursarExportFilterNegation,
+  filter: Partial<BursarExportFilterNegation>,
   feeFineTypes: FeeFineTypeDTO[],
   locations: LocationDTO[],
   stripes: StripesType,
   intl: IntlShape,
 ): CriteriaGroup {
   // NOR gets displayed as "None of" in the UI, so we flatten the inner OR
-  if (filter.criteria.type === 'Condition' && filter.criteria.operation === AndOrOperator.OR) {
+  if (filter.criteria?.type === 'Condition' && filter.criteria?.operation === AndOrOperator.OR) {
     return {
       type: CriteriaGroupType.NONE_OF,
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      criteria: filter.criteria.criteria.map((criteria) => dtoToCriteria(criteria, feeFineTypes, locations, stripes, intl)),
+      criteria: filter.criteria.criteria?.map((criteria) => dtoToCriteria(criteria, feeFineTypes, locations, stripes, intl)) ?? [],
     };
   }
 
@@ -58,7 +58,7 @@ export function dtoToNegationCriteria(
   return {
     type: CriteriaGroupType.NONE_OF,
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    criteria: [dtoToCriteria(filter.criteria, feeFineTypes, locations, stripes, intl)],
+    criteria: filter.criteria ? [dtoToCriteria(filter.criteria, feeFineTypes, locations, stripes, intl)] : [],
   };
 }
 
@@ -91,7 +91,7 @@ export function getLocationProperties(
 
 // inverse of ../to/criteriaToFilterDto
 export default function dtoToCriteria(
-  filter: BursarExportFilterDTO,
+  filter: Partial<BursarExportFilterDTO>,
   feeFineTypes: FeeFineTypeDTO[],
   locations: LocationDTO[],
   stripes: StripesType,
@@ -102,13 +102,13 @@ export default function dtoToCriteria(
       return {
         type: CriteriaTerminalType.AGE,
         operator: filter.condition as ComparisonOperator,
-        numDays: filter.numDays.toString(),
+        numDays: filter.numDays?.toString() ?? '',
       };
     case CriteriaTerminalType.AMOUNT:
       return {
         type: CriteriaTerminalType.AMOUNT,
         operator: filter.condition as ComparisonOperator,
-        amountCurrency: intl.formatNumber(filter.amount / 100, { style: 'currency', currency: stripes.currency }),
+        amountCurrency: intl.formatNumber((filter.amount ?? 0) / 100, { style: 'currency', currency: stripes.currency }),
       };
     case CriteriaTerminalType.FEE_FINE_OWNER:
       return {
@@ -118,14 +118,14 @@ export default function dtoToCriteria(
     case CriteriaTerminalType.FEE_FINE_TYPE:
       return {
         type: CriteriaTerminalType.FEE_FINE_TYPE,
-        feeFineTypeId: filter.feeFineTypeId,
-        feeFineOwnerId: getFeeFineOwnerId(filter.feeFineTypeId, feeFineTypes),
+        feeFineTypeId: filter.feeFineTypeId ?? '',
+        feeFineOwnerId: getFeeFineOwnerId(filter.feeFineTypeId ?? '', feeFineTypes),
       };
     case CriteriaTerminalType.LOCATION:
       return {
         type: CriteriaTerminalType.LOCATION,
-        locationId: filter.locationId,
-        ...getLocationProperties(filter.locationId, locations),
+        locationId: filter.locationId ?? '',
+        ...getLocationProperties(filter.locationId ?? '', locations),
       };
     case CriteriaTerminalType.PATRON_GROUP:
       return {

--- a/src/hooks/useInitialValues.test.tsx
+++ b/src/hooks/useInitialValues.test.tsx
@@ -12,31 +12,50 @@ jest.mock('../api/queries');
 (useLocations as any).mockReturnValue({ isSuccess: false });
 (useTransferAccounts as any).mockReturnValue({ isSuccess: false });
 
-test('initial values hook', async () => {
-  const { result, rerender } = renderHook(() => useInitialValues(), {
-    wrapper: ({ children }: { children: React.ReactNode }) => withIntlConfiguration(<div>{children}</div>),
+describe('useInitialValues', () => {
+  test('initial values hook', async () => {
+    const { result, rerender } = renderHook(() => useInitialValues(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => withIntlConfiguration(<div>{children}</div>),
+    });
+
+    await waitFor(() => expect(result.current).toBeNull());
+
+    (useCurrentConfig as any).mockReturnValue({ isSuccess: true });
+    rerender();
+    expect(result.current).toBeNull();
+
+    (useFeeFineTypes as any).mockReturnValue({ isSuccess: true });
+    rerender();
+    expect(result.current).toBeNull();
+
+    (useLocations as any).mockReturnValue({ isSuccess: true });
+    rerender();
+    expect(result.current).toBeNull();
+
+    (useTransferAccounts as any).mockReturnValue({ isSuccess: true });
+    rerender();
+    await waitFor(() => expect(result.current).toEqual('values'));
+
+    // should not change back
+    (useTransferAccounts as any).mockReturnValue({ isSuccess: false });
+    rerender();
+    await waitFor(() => expect(result.current).toEqual('values'));
   });
 
-  await waitFor(() => expect(result.current).toBeNull());
+  test('initial values hook with invalid data', async () => {
+    const { result, rerender } = renderHook(() => useInitialValues(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => withIntlConfiguration(<div>{children}</div>),
+    });
 
-  (useCurrentConfig as any).mockReturnValue({ isSuccess: true });
-  rerender();
-  expect(result.current).toBeNull();
+    (useTransferAccounts as any).mockReturnValue({ isSuccess: false });
 
-  (useFeeFineTypes as any).mockReturnValue({ isSuccess: true });
-  rerender();
-  expect(result.current).toBeNull();
+    // should be null on fail
+    rerender();
+    await waitFor(() => expect(result.current).toBeNull());
 
-  (useLocations as any).mockReturnValue({ isSuccess: true });
-  rerender();
-  expect(result.current).toBeNull();
+    (useTransferAccounts as any).mockReturnValue({ isSuccess: true });
+    rerender();
 
-  (useTransferAccounts as any).mockReturnValue({ isSuccess: true });
-  rerender();
-  await waitFor(() => expect(result.current).toEqual('values'));
-
-  // should not change back
-  (useTransferAccounts as any).mockReturnValue({ isSuccess: false });
-  rerender();
-  await waitFor(() => expect(result.current).toEqual('values'));
+    await waitFor(() => expect(result.current).toEqual('values'));
+  });
 });

--- a/src/hooks/useInitialValues.ts
+++ b/src/hooks/useInitialValues.ts
@@ -29,10 +29,13 @@ export default function useInitialValues() {
     if (!currentConfig.isSuccess || !feeFineTypes.isSuccess || !locations.isSuccess || !transferAccounts.isSuccess) {
       return;
     }
-
-    setInitialValues(
-      dtoToFormValues(currentConfig.data, localeWeekdays, feeFineTypes.data, locations.data, transferAccounts.data, stripes, intl)
-    );
+    try {
+      setInitialValues(
+        dtoToFormValues(currentConfig.data, localeWeekdays, feeFineTypes.data, locations.data, transferAccounts.data, stripes, intl)
+      );
+    } catch (e) {
+      setInitialValues(null);
+    }
   }, [
     currentConfig.isSuccess,
     localeWeekdays,


### PR DESCRIPTION
Per [UIPBEX-58](https://folio-org.atlassian.net/browse/UIPBEX-58), a try/catch has been added to the `useInitialValues` hook, as well as better error handling surrounding the problem areas from the failure.

I am not sure to what level of error checking we should have, so let me know if my progress so far is good and what other areas you think may need better error handling.