### PR TITLE
UIPBEX-58-fix: Check token.conditions is defined and is an array

### DIFF
--- a/src/api/dto/from/dtoToData.ts
+++ b/src/api/dto/from/dtoToData.ts
@@ -121,15 +121,18 @@ export function dtoToDataToken(
       };
 
     case 'Conditional':
-    default:
+    default: {
+      const curConditions = Array.isArray(token.conditions) ?
+        token.conditions.map(condition => ({
+          ...dtoToCriteria(condition.condition, feeFineTypes, locations, stripes, intl), value: condition.value.value
+        })) : [];
+
       return {
         type: DataTokenType.CONSTANT_CONDITIONAL,
-        conditions: token.conditions.map((condition) => ({
-          ...dtoToCriteria(condition.condition, feeFineTypes, locations, stripes, intl),
-          value: condition.value.value,
-        })),
+        conditions: curConditions,
         else: token.else.value,
       };
+    }
   }
 }
 


### PR DESCRIPTION
Continued on [UIPBEX-58](https://folio-org.atlassian.net/jira/software/c/projects/UIPBEX/issues/UIPBEX-58?jql=project%20%3D%20%22UIPBEX%22%20ORDER%20BY%20created%20DESC).

How does this look as a preventative fix? Looks like the issue is coming from this, a conditional text without 'condition' was saved. So we want to prevent this from being saved without a condition right?


<img width="1436" alt="Screenshot 2024-05-08 at 3 37 45 PM" src="https://github.com/folio-org/ui-plugin-bursar-export/assets/97154067/38899a6c-a93d-4d46-99e2-20be2a8e8f02">
