### PR TITLE
[FOLIO-4086] Fix GitHub Actions workflow not running for tags

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   ui:
     uses: folio-org/.github/.github/workflows/ui.yml@v1
-    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit
     with:
       jest-enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change history for ui-plugin-bursar-export
 
+## IN PROGRESS
+* Fix GitHub Actions workflow not running for tags. Refs FOLIO-4086.
+
 ## [4.0.2](https://github.com/folio-org/ui-plugin-bursar-export/tree/v4.0.2) (2024-05-08)
 [Full Changelog](https://github.com/folio-org/ui-plugin-bursar-export/compare/v4.0.1...v4.0.2)
-Check token.conditions is defined and is an array. Refs UIPBEX-58.
+* Check token.conditions is defined and is an array. Refs UIPBEX-58.
 
 ## [4.0.1](https://github.com/folio-org/ui-plugin-bursar-export/tree/v4.0.1) (2024-04-25)
 [Full Changelog](https://github.com/folio-org/ui-plugin-bursar-export/compare/v4.0.0...v4.0.1)


### PR DESCRIPTION
# [Jira FOLIO-4086](https://folio-org.atlassian.net/browse/FOLIO-4086)

Due to an error in the [recommended configuration for shared workflows](https://github.com/folio-org/.github/blob/master/README-UI.md), an incorrect conditional was added to the workflow which can cause GitHub Actions to not run on tags, making it impossible to release this module.

This PR resolves this by adjusting the condition to always run the workflow for pushes to tags.
