### PR TITLE
[UIPBEX-70] Add dryRun option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Dependency correction: `react-intl` bumped to v7 in UIPBEX-66 but we missed the peer. Refs UIPBEX-72.
 * Transfer criteria: footer format overridden by header format after save. Refs UIPBEX-73.
+* Support running exports as a dry run. Refs UIPBEX-70.
 
 ## [5.0.1](https://github.com/folio-org/ui-plugin-bursar-export/tree/v5.0.1) (2025-11-13) Sunflower CSP #3
 

--- a/src/api/dto/dto-types.ts
+++ b/src/api/dto/dto-types.ts
@@ -15,6 +15,7 @@ export interface BursarExportJobDTO {
   data?: BursarExportDataTokenDTO[];
   footer?: BursarExportHeaderFooterTokenDTO[];
   transferInfo: BursarExportTransferCriteria;
+  dryRun?: boolean;
 }
 
 export type BursarExportFilterDTO =

--- a/src/api/dto/from/dtoToFormValues.test.ts
+++ b/src/api/dto/from/dtoToFormValues.test.ts
@@ -49,6 +49,38 @@ describe('dtoToFormValues', () => {
           conditions: [],
           else: { account: 'account' },
         },
+        dryRun: false,
+      },
+    ],
+    [
+      {
+        id: 'id',
+        type: 'BURSAR_FEES_FINES',
+        tenant: 'diku',
+        schedulePeriod: SchedulingFrequency.Manual,
+        exportTypeSpecificParameters: {
+          bursarFeeFines: {
+            groupByPatron: false,
+            data: [{ type: 'Constant', value: '\n' }],
+            filter: { type: 'Pass' },
+            transferInfo: { else: { account: 'account' } },
+            header: [{ type: 'Constant', value: '\n' }],
+            dryRun: true,
+          },
+        },
+      },
+      {
+        scheduling: { frequency: SchedulingFrequency.Manual },
+        criteria: { type: CriteriaTerminalType.PASS },
+        aggregate: false,
+        header: [{ type: HeaderFooterTokenType.NEWLINE }],
+        data: [{ type: DataTokenType.NEWLINE }],
+        footer: [],
+        transferInfo: {
+          conditions: [],
+          else: { account: 'account' },
+        },
+        dryRun: true,
       },
     ],
     [
@@ -77,7 +109,12 @@ describe('dtoToFormValues', () => {
           conditions: [],
           else: { account: 'account' },
         },
+        dryRun: false,
       },
     ],
-  ])('Converts DTO %s to %s', (input, expected) => expect(dtoToFormValues(input, [], [], [], [], { currency: 'USD' } as StripesType, intlEn)).toEqual(expected));
+  ])('Converts DTO %s to %s', (input, expected) =>
+    expect(
+      dtoToFormValues(input, [], [], [], [], { currency: 'USD' } as StripesType, intlEn),
+    ).toEqual(expected),
+  );
 });

--- a/src/api/dto/from/dtoToFormValues.ts
+++ b/src/api/dto/from/dtoToFormValues.ts
@@ -26,45 +26,61 @@ export default function dtoToFormValues(
     return {};
   }
 
+  const commonValues = {
+    scheduling: dtoToScheduling(values, localeWeekdays),
+
+    criteria: dtoToCriteria(
+      values.exportTypeSpecificParameters.bursarFeeFines.filter,
+      feeFineTypes,
+      locations,
+      stripes,
+      intl,
+    ),
+
+    header: dtoToHeaderFooter(values.exportTypeSpecificParameters.bursarFeeFines.header),
+    footer: dtoToHeaderFooter(values.exportTypeSpecificParameters.bursarFeeFines.footer),
+
+    transferInfo: dtoToTransfer(
+      values.exportTypeSpecificParameters.bursarFeeFines.transferInfo,
+      feeFineTypes,
+      locations,
+      transferAccounts,
+      stripes,
+      intl,
+    ),
+
+    dryRun: values.exportTypeSpecificParameters.bursarFeeFines.dryRun === true,
+  };
+
   if (values.exportTypeSpecificParameters.bursarFeeFines.groupByPatron) {
     return {
-      scheduling: dtoToScheduling(values, localeWeekdays),
-
-      criteria: dtoToCriteria(values.exportTypeSpecificParameters.bursarFeeFines.filter, feeFineTypes, locations, stripes, intl),
+      ...commonValues,
 
       aggregate: true,
-      aggregateFilter: dtoToAggregateCriteria(values.exportTypeSpecificParameters.bursarFeeFines.groupByPatronFilter, stripes, intl),
+      aggregateFilter: dtoToAggregateCriteria(
+        values.exportTypeSpecificParameters.bursarFeeFines.groupByPatronFilter,
+        stripes,
+        intl,
+      ),
 
-      header: dtoToHeaderFooter(values.exportTypeSpecificParameters.bursarFeeFines.header),
-      dataAggregate: dtoToData(values.exportTypeSpecificParameters.bursarFeeFines.data, feeFineTypes, locations, stripes, intl),
-      footer: dtoToHeaderFooter(values.exportTypeSpecificParameters.bursarFeeFines.footer),
-
-      transferInfo: dtoToTransfer(
-        values.exportTypeSpecificParameters.bursarFeeFines.transferInfo,
+      dataAggregate: dtoToData(
+        values.exportTypeSpecificParameters.bursarFeeFines.data,
         feeFineTypes,
         locations,
-        transferAccounts,
         stripes,
         intl,
       ),
     };
   } else {
     return {
-      scheduling: dtoToScheduling(values, localeWeekdays),
-
-      criteria: dtoToCriteria(values.exportTypeSpecificParameters.bursarFeeFines.filter, feeFineTypes, locations, stripes, intl),
+      ...commonValues,
 
       aggregate: false,
 
-      header: dtoToHeaderFooter(values.exportTypeSpecificParameters.bursarFeeFines.header),
-      data: dtoToData(values.exportTypeSpecificParameters.bursarFeeFines.data, feeFineTypes, locations, stripes, intl),
-      footer: dtoToHeaderFooter(values.exportTypeSpecificParameters.bursarFeeFines.footer),
-
-      transferInfo: dtoToTransfer(
-        values.exportTypeSpecificParameters.bursarFeeFines.transferInfo,
+      data: dtoToData(
+        values.exportTypeSpecificParameters.bursarFeeFines.data,
         feeFineTypes,
         locations,
-        transferAccounts,
         stripes,
         intl,
       ),

--- a/src/api/dto/to/formValuesToDto.test.ts
+++ b/src/api/dto/to/formValuesToDto.test.ts
@@ -63,6 +63,7 @@ describe('Form values conversion', () => {
       ],
       else: { account: 'else-sp' },
     },
+    dryRun: false,
   };
 
   it('converts non-aggregate values', () => expect(formValuesToDto({ ...TEST_VALUE, aggregate: false })).toEqual({

--- a/src/api/dto/to/formValuesToDto.ts
+++ b/src/api/dto/to/formValuesToDto.ts
@@ -7,26 +7,30 @@ import headerFooterToDto from './headerFooterToDto';
 import transferToDto from './transferToDto';
 
 export default function formValuesToDto(values: FormValues): BursarExportJobDTO {
+  const common = {
+    filter: criteriaToFilterDto(values.criteria),
+
+    header: headerFooterToDto(values.header),
+    footer: headerFooterToDto(values.footer),
+
+    dryRun: values.dryRun === true,
+    transferInfo: transferToDto(values.transferInfo),
+  };
   if (values.aggregate) {
     return {
-      filter: criteriaToFilterDto(values.criteria),
+      ...common,
       groupByPatron: true,
       groupByPatronFilter: aggregateCriteriaToFilterDto(values.aggregateFilter),
 
-      header: headerFooterToDto(values.header),
       data: dataToDto(values.dataAggregate),
-      footer: headerFooterToDto(values.footer),
-      transferInfo: transferToDto(values.transferInfo),
     };
   } else {
     return {
-      filter: criteriaToFilterDto(values.criteria),
+      ...common,
       groupByPatron: false,
 
       header: headerFooterToDto(values.header),
       data: dataToDto(values.data),
-      footer: headerFooterToDto(values.footer),
-      transferInfo: transferToDto(values.transferInfo),
     };
   }
 }

--- a/src/components/Card.module.css
+++ b/src/components/Card.module.css
@@ -16,6 +16,6 @@
   padding: 0;
 }
 
-.aggregateCardP {
+.aggregateCardP, .dryRunCardP {
   margin-bottom: 0;
 }

--- a/src/components/ConfigurationForm.tsx
+++ b/src/components/ConfigurationForm.tsx
@@ -13,7 +13,7 @@ import {
   ExportPreviewSection,
   HeaderFooterSection,
   SchedulingSection,
-  TransferInfoSection
+  TransferSection
 } from './FormSection';
 
 interface ConfigurationFormSectionProps {
@@ -77,7 +77,7 @@ function ConfigurationFormSection({ handleSubmit, formApiRef, form }: FormRender
         </Accordion>
 
         <Accordion label={<FormattedMessage id="ui-plugin-bursar-export.bursarExports.transfer.accordion" />}>
-          <TransferInfoSection />
+          <TransferSection />
         </Accordion>
       </AccordionSet>
     </form>

--- a/src/components/FormSection/TransferSection.tsx
+++ b/src/components/FormSection/TransferSection.tsx
@@ -1,0 +1,42 @@
+import { Card, Checkbox } from '@folio/stripes/components';
+import React from 'react';
+import { Field, useField } from 'react-final-form';
+import { FormattedMessage, useIntl } from 'react-intl';
+import css from '../Card.module.css';
+import TransferInfoSection from './TransferInfoSection';
+
+export default function TransferSection() {
+  const intl = useIntl();
+  const isDryRun =
+    useField<boolean>('dryRun', {
+      subscription: { value: true },
+    }).input.value === true;
+
+  return (
+    <>
+      <Card
+        headerStart={
+          <FormattedMessage id="ui-plugin-bursar-export.bursarExports.transfer.dryRunHeader" />
+        }
+      >
+        <Field name="dryRun" type="checkbox" defaultValue={false}>
+          {(fieldProps) => (
+            <Checkbox
+              {...fieldProps}
+              fullWidth
+              label={intl.formatMessage({
+                id: 'ui-plugin-bursar-export.bursarExports.transfer.dryRunCheckbox',
+              })}
+            />
+          )}
+        </Field>
+
+        <p className={css.dryRunCardP}>
+          <FormattedMessage id="ui-plugin-bursar-export.bursarExports.transfer.dryRunDescription" />
+        </p>
+      </Card>
+
+      {!isDryRun && <TransferInfoSection />}
+    </>
+  );
+}

--- a/src/components/FormSection/index.ts
+++ b/src/components/FormSection/index.ts
@@ -5,3 +5,4 @@ export { default as ExportPreviewSection } from './ExportPreviewSection';
 export { default as HeaderFooterSection } from './HeaderFooterSection';
 export { default as SchedulingSection } from './SchedulingSection';
 export { default as TransferInfoSection } from './TransferInfoSection';
+export { default as TransferSection } from './TransferSection';

--- a/src/types/FormValues.ts
+++ b/src/types/FormValues.ts
@@ -38,5 +38,7 @@ export default interface FormValues {
     };
   };
 
+  dryRun?: boolean;
+
   buttonClicked?: 'save' | 'manual';
 }

--- a/translations/ui-plugin-bursar-export/en.json
+++ b/translations/ui-plugin-bursar-export/en.json
@@ -167,6 +167,9 @@
   "bursarExports.preview.enableInvisibleChar": "Display invisible characters (newlines, tabs, and spaces)",
 
   "bursarExports.transfer.accordion": "Transfer accounts to",
+  "bursarExports.transfer.dryRunHeader": "Testing mode",
+  "bursarExports.transfer.dryRunCheckbox": "Enable testing mode",
+  "bursarExports.transfer.dryRunDescription": "When enabled, the export will be generated and processed as usual, however, accounts will not be transferred. This allows you to verify that your criteria are properly configured before performing actual transfers.",
   "bursarExports.transfer.description": "Conditions will be evaluated in order, with the first matched transfer account being used. If no conditions are matched, the account listed under \u201cotherwise\u201d will be used.",
   "bursarExports.transfer.owner": "Fee/fine owner",
   "bursarExports.transfer.account": "Transfer account",


### PR DESCRIPTION
# [Jira UIPBEX-70](https://folio-org.atlassian.net/browse/UIPBEX-70)

## Purpose
Users would like to run bursar exports without the underlying accounts being transferred. This allows easier testing and verification of the export configurations before any data are actually changed.

## Approach
This adds a checkbox in the transfer settings accordion to disable or enable "testing mode". Enabling this checkbox will hide the transfer configuration and enable the `dryRun` flag passed to the API.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
